### PR TITLE
fix(nginx): update zlib download URL (zlib.net returning 404)

### DIFF
--- a/apps/nginx/Dockerfile
+++ b/apps/nginx/Dockerfile
@@ -32,7 +32,7 @@ RUN git clone -j$(nproc) -b "${OPENSSL_VER}" https://github.com/openssl/openssl.
 # download zlib
 WORKDIR /src/zlib
 ARG ZLIB_VER=1.3.1
-RUN curl -sL -O "https://www.zlib.net/zlib-${ZLIB_VER}.tar.gz" \
+RUN curl -sL -O "https://github.com/madler/zlib/releases/download/v${ZLIB_VER}/zlib-${ZLIB_VER}.tar.gz" \
     && tar xzf "zlib-${ZLIB_VER}.tar.gz"
 
 # download brotli module


### PR DESCRIPTION
Problem: Scheduled release CI failing - zlib source URL returns 404 HTML page causing gzip invalid magic tar errors. Fix: Use official GitHub release mirror for zlib instead of broken zlib.net link.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the zlib download source to improve build reliability while preserving the existing version and installation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Updates the nginx image build to download zlib 1.3.1 from the official GitHub release mirror instead of the unavailable zlib.net URL.
- Preserves the existing zlib version, archive filename, and extraction behavior.
- Continues following redirects required by the release download.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because the replacement URL matches the existing zlib version and archive naming contract.

The nginx build continues downloading and extracting zlib 1.3.1 under the same filename, while the existing redirect-following curl option supports the new release URL.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/nginx/Dockerfile | Replaces the broken zlib.net download URL with the matching official GitHub release asset; no correctness issues identified. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(nginx): update zlib download URL (zl..."](https://github.com/coolguy1771/containers/commit/b5bb3bbf865846ea288331f7a6e414add98863d6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49219684)</sub>

<!-- /greptile_comment -->