### PR TITLE
fix(nginx): update zlib download URL (zlib.net returning 404)

### DIFF
--- a/apps/nginx/Dockerfile
+++ b/apps/nginx/Dockerfile
@@ -32,7 +32,7 @@ RUN git clone -j$(nproc) -b "${OPENSSL_VER}" https://github.com/openssl/openssl.
 # download zlib
 WORKDIR /src/zlib
 ARG ZLIB_VER=1.3.1
-RUN curl -sL -O "https://www.zlib.net/zlib-${ZLIB_VER}.tar.gz" \
+RUN curl -sL -O "https://github.com/madler/zlib/releases/download/v${ZLIB_VER}/zlib-${ZLIB_VER}.tar.gz" \
     && tar xzf "zlib-${ZLIB_VER}.tar.gz"
 
 # download brotli module


### PR DESCRIPTION
Problem: Scheduled release CI failing - zlib source URL returns 404 HTML page causing gzip invalid magic tar errors. Fix: Use official GitHub release mirror for zlib instead of broken zlib.net link.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the zlib download source to improve reliability during container builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Updates the nginx container build to download zlib 1.3.1 from the official GitHub release mirror instead of the unavailable zlib.net URL.
- Preserves the existing version, archive filename, and extraction flow.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

The configured zlib version resolves through the new release URL while retaining the archive name expected by the subsequent extraction command, and repository build configuration does not override that version.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/nginx/Dockerfile | Replaces the failing zlib.net source URL with the corresponding official GitHub release asset without altering build behavior. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(nginx): update zlib download URL (zl..."](https://github.com/coolguy1771/containers/commit/b5bb3bbf865846ea288331f7a6e414add98863d6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49220071)</sub>

<!-- /greptile_comment -->