### PR TITLE
fix(ci): add packages:write permission to calling workflows

### DIFF
--- a/.github/workflows/pr-validate.yaml
+++ b/.github/workflows/pr-validate.yaml
@@ -7,6 +7,10 @@ on:
     branches: ["main"]
     types: ["opened", "synchronize", "reopened"]
 
+permissions:
+  contents: read
+  packages: write
+
 concurrency:
   group: ${{ github.head_ref }}-pr-validate
   cancel-in-progress: true

--- a/.github/workflows/release-on-merge.yaml
+++ b/.github/workflows/release-on-merge.yaml
@@ -2,6 +2,10 @@
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 name: Release on Merge
 
+permissions:
+  contents: read
+  packages: write
+
 concurrency:
   group: container-release
   cancel-in-progress: false

--- a/.github/workflows/release-scheduled.yaml
+++ b/.github/workflows/release-scheduled.yaml
@@ -2,6 +2,10 @@
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 name: Scheduled Release
 
+permissions:
+  contents: read
+  packages: write
+
 concurrency:
   group: container-release
   cancel-in-progress: false
@@ -32,9 +36,6 @@ jobs:
     needs: simple-checks
     uses: ./.github/workflows/build-images.yaml
     secrets: inherit
-    permissions:
-      contents: read
-      packages: write
     with:
       appsToBuild: ${{ inputs.appsToBuild }}
       force: ${{ inputs.force == true }}


### PR DESCRIPTION
## Problem

All PR and push-triggered CI pipelines have been failing with  since July 16. Root cause identified:

```
Error calling workflow 'build-images.yaml'. The nested job 'build-platform-images' 
is requesting 'packages: write', but is only allowed 'packages: read'.
```

## Fix

Added `permissions: { contents: read, packages: write }` at the top level of:

- pr-validate.yaml  
- release-on-merge.yaml  
- release-scheduled.yaml  

When reusable workflows are called from another workflow, they inherit token scopes. PR events default to , so the calling workflow must explicitly grant .

Note: With local relative-path reusable workflow calls (), permissions **must** be at top-level — job-level overrides are ignored.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated validation and release workflows with the permissions required to access repository contents and publish packages.
  * Standardized workflow-level permission settings for scheduled releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR grants the calling CI workflows the package-write scope required by the reusable image-building workflow.
- Adds workflow-level `contents: read` and `packages: write` permissions to pull-request validation, merge releases, and scheduled releases.
- Removes the redundant job-level permission declaration from the scheduled release workflow.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with a non-blocking opportunity to narrow package-write access in reusable jobs that never publish packages.

The caller-level grant fixes the reusable image workflow’s authorization failure, but unrelated validation, change-discovery, and documentation jobs now inherit package-publishing capability while executing third-party actions.

**Files Needing Attention:** .github/workflows/pr-validate.yaml, .github/workflows/release-on-merge.yaml, .github/workflows/release-scheduled.yaml
</details>

<details open><summary><h3>Security Review</h3></summary>

The workflow-level package-write grant also reaches non-publishing reusable jobs; narrowing permissions within those jobs would reduce exposure to third-party action compromise.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/pr-validate.yaml | Adds the required caller-level package permission, but consequently grants package-write access to non-publishing PR validation jobs. |
| .github/workflows/release-on-merge.yaml | Adds caller-level read and package-write permissions for release workflows, broadening the scope inherited by validation and README jobs. |
| .github/workflows/release-scheduled.yaml | Moves package permissions from the image-build call to workflow level, fixing inheritance while widening access to other called jobs. |

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0A.github%2Fworkflows%2Fpr-validate.yaml%3A10-13%0A**Package%20scope%20reaches%20validation%20jobs**%0A%0AThe%20workflow-level%20%60packages%3A%20write%60%20permission%20is%20inherited%20by%20non-publishing%20reusable%20jobs%20such%20as%20%60simple-checks%60%20and%20%60get-changed-images%60%2C%20which%20execute%20third-party%20actions%20pinned%20to%20mutable%20version%20tags.%20This%20unnecessarily%20gives%20those%20actions%20the%20ability%20to%20publish%20or%20overwrite%20repository%20packages%3B%20narrow%20permissions%20within%20the%20non-publishing%20reusable%20jobs%20while%20retaining%20the%20caller-level%20grant%20required%20by%20the%20image%20workflow.%0A%0A**How%20this%20was%20verified%3A**%20The%20caller-wide%20grant%20was%20traced%20into%20reusable%20jobs%20that%20declare%20no%20narrower%20permissions%20and%20execute%20mutable-tag%20third-party%20actions.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=113&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0A.github%2Fworkflows%2Fpr-validate.yaml%3A10-13%0A**Package%20scope%20reaches%20validation%20jobs**%0A%0AThe%20workflow-level%20%60packages%3A%20write%60%20permission%20is%20inherited%20by%20non-publishing%20reusable%20jobs%20such%20as%20%60simple-checks%60%20and%20%60get-changed-images%60%2C%20which%20execute%20third-party%20actions%20pinned%20to%20mutable%20version%20tags.%20This%20unnecessarily%20gives%20those%20actions%20the%20ability%20to%20publish%20or%20overwrite%20repository%20packages%3B%20narrow%20permissions%20within%20the%20non-publishing%20reusable%20jobs%20while%20retaining%20the%20caller-level%20grant%20required%20by%20the%20image%20workflow.%0A%0A**How%20this%20was%20verified%3A**%20The%20caller-wide%20grant%20was%20traced%20into%20reusable%20jobs%20that%20declare%20no%20narrower%20permissions%20and%20execute%20mutable-tag%20third-party%20actions.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=coolguy1771%2Fcontainers&pr=113&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22coolguy1771%2Fcontainers%22%20on%20the%20existing%20branch%20%22fix%2Fci-workflow-permissions%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fci-workflow-permissions%22.%0A%0A%23%23%23%20Issue%201%0A.github%2Fworkflows%2Fpr-validate.yaml%3A10-13%0A**Package%20scope%20reaches%20validation%20jobs**%0A%0AThe%20workflow-level%20%60packages%3A%20write%60%20permission%20is%20inherited%20by%20non-publishing%20reusable%20jobs%20such%20as%20%60simple-checks%60%20and%20%60get-changed-images%60%2C%20which%20execute%20third-party%20actions%20pinned%20to%20mutable%20version%20tags.%20This%20unnecessarily%20gives%20those%20actions%20the%20ability%20to%20publish%20or%20overwrite%20repository%20packages%3B%20narrow%20permissions%20within%20the%20non-publishing%20reusable%20jobs%20while%20retaining%20the%20caller-level%20grant%20required%20by%20the%20image%20workflow.%0A%0A**How%20this%20was%20verified%3A**%20The%20caller-wide%20grant%20was%20traced%20into%20reusable%20jobs%20that%20declare%20no%20narrower%20permissions%20and%20execute%20mutable-tag%20third-party%20actions.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=coolguy1771%2Fcontainers&pr=113&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
.github/workflows/pr-validate.yaml:10-13
**Package scope reaches validation jobs**

The workflow-level `packages: write` permission is inherited by non-publishing reusable jobs such as `simple-checks` and `get-changed-images`, which execute third-party actions pinned to mutable version tags. This unnecessarily gives those actions the ability to publish or overwrite repository packages; narrow permissions within the non-publishing reusable jobs while retaining the caller-level grant required by the image workflow.

**How this was verified:** The caller-wide grant was traced into reusable jobs that declare no narrower permissions and execute mutable-tag third-party actions.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): add packages:write permission t..."](https://github.com/coolguy1771/containers/commit/f174d2e083f34136fa89bf27eb38277c74207030) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49227871)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->